### PR TITLE
FIX Show alpha directory

### DIFF
--- a/en/04_Changelogs/index.md
+++ b/en/04_Changelogs/index.md
@@ -15,7 +15,7 @@ As of Silverstripe CMS 4, these changelogs track **recipe** versions (`silverstr
 
 ---
 
-[CHILDREN Only="rc,beta" includeFolders]
+[CHILDREN Only="rc,beta,alpha" includeFolders]
 
 ---
 


### PR DESCRIPTION
There's a changelog for 5.0.0-alpha1: https://docs.silverstripe.org/en/5/changelogs/alpha/5.0.0-alpha1/
This should be findable without having to know the URL

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/590